### PR TITLE
Optimize copy operations

### DIFF
--- a/finediff.php
+++ b/finediff.php
@@ -38,6 +38,11 @@
  * 15-Jul-2013 (Peter Bagnall):
  *   - fixed bug where getting the diff of "abc def" and "abc def ghi" would fail
  *     to recognise that def was a match, because whitespace was being included in fragments.
+ *
+ * 23-Nov-2015 (Tien Vo Xuan):
+ *   - Improve copy operations in opcodes, e.g. When getting the diff of 'comes the sun comes the sun'
+ *     and 'Here comes the sun. Here comes the sun, and I say, It's all right',
+ *     it should return 'd5c13d7i2:, c13d27' instead of 'd4i13:comes the sunc14d47'.
 */
 
 mb_internal_encoding('UTF-8');


### PR DESCRIPTION
###### What is the problem?

When whe compare _comes the sun comes the sun_ with _Here comes the sun. Here comes the sun, and I say, It's all right_ we will got **d4i13:comes the sunc14d47**. This is because PHP-FineDiff only choose the best single copy operation, which is _[space]comes the sun_ (14 characters).
###### What can we do?

Move copy operations into groups. Each groups has operations that do not conflict with each other.
The we can loop through each loop and find out which group is the best. In this case, the group has 2 copy operations which are _comes the sun_ and _comes the sun_ (13+13 = 26 characters) is the best group. The opcode will be **d5c13d7i: c13d27**
